### PR TITLE
Setup homebrew and ubuntu for jobs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,11 +32,17 @@ jobs:
           GITHUB_API_TOKEN: ${{ github.token }}
 
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Install bats
+        run: brew install bats-core
 
       - name: Install asdf
         run: git clone https://github.com/asdf-vm/asdf.git $HOME/asdf
@@ -50,11 +56,14 @@ jobs:
           GITHUB_API_TOKEN: ${{ github.token }}
 
   lint:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
       - name: Install shellcheck
         run: brew install shellcheck
@@ -63,11 +72,14 @@ jobs:
         run: shellcheck bin/*
 
   format:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
 
       - name: Install shfmt
         run: brew install shfmt


### PR DESCRIPTION
Standardize dependency installation with Homebrew and use `ubuntu-latest` for `test`, `lint`, and `format` jobs.

---
<a href="https://cursor.com/background-agent?bcId=bc-156f8642-586d-45ee-aaf4-e460e110556b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-156f8642-586d-45ee-aaf4-e460e110556b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches CI jobs to ubuntu-latest and installs tools via Homebrew, adding setup-homebrew and bats-core where needed.
> 
> - **CI Workflow (`.github/workflows/workflow.yml`)**:
>   - **Runners**: Change `test`, `lint`, and `format` jobs from `macos-latest` to `ubuntu-latest`.
>   - **Homebrew Setup**: Add `Homebrew/actions/setup-homebrew@master` to `test`, `lint`, and `format` jobs.
>   - **Tooling**:
>     - `test`: Install `bats-core` via `brew` and run `bats test` after adding the `sml` plugin.
>     - `lint`: Install `shellcheck` via `brew` and run ShellCheck on `bin/*`.
>     - `format`: Install `shfmt` via `brew` and run `shfmt -d -i 2 -ci .`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa3c0141b298d7204bdd8515f74a7dacf52ee17a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->